### PR TITLE
removed caseInsensitiveCompare: for being too advanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ NSLog(@"%@", instructorNames);
 ```
 This will print: `Joe! Tim! Tom! Jim! and Mark!`.
 
-### String Comparators
+### Matching Strings
 
-You can compare two strings to see if they are a match. There are several methods of varying precision which you can use to do this. Using the `isEqualToString:` method will only evaluate as true (return `YES`) if the strings are exactly alike. This is useful for something like a password check:
+You can compare two strings to see if they are a match. Using the `isEqualToString:` method will only evaluate as true (return `YES`) if the strings are exactly alike. This is useful for something like a password check:
 
 ```objc
 NSString *password = @"p@ssw0rd";
@@ -144,23 +144,7 @@ if (isValidPassword) {
 ```
 This will print: `Welcome to the Flatiron School!`.
 
-**Top Tip:** *A common mistake in comparing strings is using the* `==` *("is identical to") comparator which will only return* `YES` *if the two strings are the exact same instance. This will rarely be the case when comparing strings so the* `isEqualToString` *method—which evaluates if the strings are equivalent—will almost always be the check that you want.* 
-
-There is the `caseInsensitiveCompare:` method which will ignore capitalization. It's equivalent to running `lowercaseString` on both strings and then comparing them with `isEqualToString:`, but that's more code and more work.
-
-```objc
-NSString *username = @"mark";
-NSString *uppercaseUsername = @"MARK";
-
-BOOL isUniqueUsername = [username caseInsensitiveCompare:uppercaseUsername];
-
-if (!isUniqueUsername) {
-	NSLog(@"That username is already taken.");
-}
-```
-This will print: `That username is already taken`.
-
-The `compare:options:range:locale` method family will be useful once you learn how to select these different parameter types. For now, just learn about the two methods above.
+A common mistake in comparing strings is using the `==` ("is identical to") mathematical comparator. This **happens** to work with strings because of the way Objective-C handles them, but for all other objects, using the `==` comparator will only return `YES` if the two objects are the *exact same object (i.e. "instance").* This will rarely be the case when comparing objects so get accustomed to using the appropriate `isEqualTo...` method when working with objects. 
 
 #### Converting to NSInteger
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ NSString *whisperWelcome = @"welcome to the flatiron school!";
 NSString *whisperWelcomeUC = [whisperWelcome uppercaseString];
 
 if ([loudWelcome isEqualToString:whisperWelcomeUC]) {
-    NSLog(@"Speak up when you say that, silly!");
+    NSLog(@"WE LOVE THAT ENTHUSIASM!");
 } else {
-    NSLog(@"Are you sure you said that right?");
+    NSLog(@"Speak up when you say that!");
 }
 ```
-This will print: `Speak up when you say that, silly!`.
+This will print: `WE LOVE THAT ENTHUSIASM!`.
 
 ### Converting to NSInteger
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ There are many ways of creating strings, but this is the most common, especially
 
 Manipulating the case of a characters in a string can sometimes be useful. Calling `lowercaseString` converts all of the uppercase characters to lowercase characters, calling `uppercaseString` does the opposite, and calling `capitalizedString` will capitalize only the first letter of each word, as separated by a space or punctuation mark.
 
+```objc
+NSString *welcome = @"Welcome to the Flatiron School!";
+NSString *welcomeUppercasified = [welcome uppercaseString];
+
+NSLog(@"%@", welcomeUppercasified);
+```
+This will print: `WELCOME TO THE FLATIRON SCHOOL!`.
+
 ***A Note on Type Cases:***
 
 The Objective-C language utilizes a fusion of what are called "camel case" and "capital case." Both of these omit spaces in favor of capitalizing the first letter of each word. They differ in that camel case begins with a lowercase letter, while capital case begins with an uppercase letter.
@@ -69,6 +77,8 @@ if (isMarquis && isLafayette) {
 }
 ```
 This will print the Marquis' introduction.
+
+**Advanced:** *A* `BOOL` *is a type of variable that holds either a* `YES` *or a* `NO`. *The* `if` *statement evaluates* `BOOL`*s and makes a decision based on their statuses. We'll discuss these more in future readings.*
 
 ### String Concatenation
 
@@ -146,7 +156,25 @@ This will print: `Welcome to the Flatiron School!`.
 
 A common mistake in comparing strings is using the `==` ("is identical to") mathematical comparator. This **happens** to work with strings because of the way Objective-C handles them, but for all other objects, using the `==` comparator will only return `YES` if the two objects are the *exact same object (i.e. "instance").* This will rarely be the case when comparing objects so get accustomed to using the appropriate `isEqualTo...` method when working with objects. 
 
-#### Converting to NSInteger
+#### Evaluating Case
+
+You can combine the use of `isEqualToString:` method with the `uppercaseString`, `lowercaseString`, and `capitalizedString` methods to check the original string's case:
+
+```objc
+NSString *loudWelcome = @"WELCOME TO THE FLATIRON SCHOOL!";
+NSString *whisperWelcome = @"welcome to the flatiron school!";
+
+NSString *whisperWelcomeUC = [whisperWelcome uppercaseString];
+
+if ([loudWelcome isEqualToString:whisperWelcomeUC]) {
+    NSLog(@"Speak up when you say that, silly!");
+} else {
+    NSLog(@"Are you sure you said that right?");
+}
+```
+This will print: `Speak up when you say that, silly!`.
+
+### Converting to NSInteger
 
 A number saved as a string is visible to the processor as text—that's fine for humans to read, but math can't be performed on it. To convert a string to an `NSInteger`, there's a handy method named `integerValue` that you can run on a string which contains a value that you wish to access. While there's a method to convert a string to each of the data types, here's an example of the `integerValue` method:
 
@@ -224,6 +252,6 @@ NSLog(@"%@", greeting);
 ```
 This will print: `Hello, my name is Mark! I am 29 years old.`.
 
-Did you notice how we called the `stringWithFormat:` method by sending it to `NSString` itself? That's because `stringWithFormat:`'s purpose is to create a new string—not to modify an existing string—so it's a method call that has to be sent to `NSString` itself. This makes `stringWithFormat:` a **class method**. We'll discuss this distinction in more detail when we talk about inheritance.
+Did you notice how we called the `stringWithFormat:` method by sending it to `NSString` itself? That's because `stringWithFormat:`'s purpose is to create a new string—not to modify an existing string—so it's a method call that has to be sent to `NSString` itself. This makes `stringWithFormat:` a **class method**. We'll discuss this distinction in more detail when we talk about object orientation.
 
 


### PR DESCRIPTION
https://github.com/learn-co-curriculum/reading-ios-things-nsstring-can-do/issues/7

`caseInsensitiveCompare:` returns an `NSComparisonResult` not a `BOOL`. It seems best just to leave it out at this early point in the curriculum.